### PR TITLE
Handle error responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,11 @@ exports.register = function (server, options, next) {
 		Object.keys(options.headers).forEach((key) => {
 			const obj = options.headers[key];
 			const value = typeof obj === 'function' ? obj(request) : obj;
-			request.response.header(key, value);
+			if (request.response.isBoom) {
+				request.response.output.headers[key] = value;
+			} else {
+				request.response.header(key, value);
+			}
 		});
 		reply.continue();
 	});

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@aptoma/eslint-config": "^4.0.0",
+    "boom": "^3.1.3",
     "chai": "3.5.0",
     "eslint": "^2.3.0",
     "hapi": "^13.0.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -28,25 +28,21 @@ describe('Hapi Static Headers', () => {
 					}
 				}
 			}
-		}, (err) => {
-			if (err) {
-				return done(err);
-			}
-
-			server.route({method: 'GET', path: '/', handler: (req, reply) => reply()});
-
-			server
-				.inject({
-					url: '/',
-					method: 'GET',
-					headers: {test: 'foobar'}
-				})
-				.then((res) => {
-					assert(res.headers.foo === 'bar');
-					assert(res.headers.boo === 'foobar');
-					done();
-				});
-		});
-
+		})
+			.then(() => {
+				server.route({method: 'GET', path: '/', handler: (req, reply) => reply()});
+				server
+					.inject({
+						url: '/',
+						method: 'GET',
+						headers: {test: 'foobar'}
+					})
+					.then((res) => {
+						assert(res.headers.foo === 'bar');
+						assert(res.headers.boo === 'foobar');
+						done();
+					});
+			})
+			.catch(done);
 	});
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,6 +2,7 @@
 
 const Hapi = require('hapi');
 const assert = require('chai').assert;
+const Boom = require('boom');
 
 describe('Hapi Static Headers', () => {
 	it('should require object option', (done) => {
@@ -40,6 +41,33 @@ describe('Hapi Static Headers', () => {
 					.then((res) => {
 						assert(res.headers.foo === 'bar');
 						assert(res.headers.boo === 'foobar');
+						done();
+					});
+			})
+			.catch(done);
+	});
+
+	it('should add headers to error responses', (done) => {
+		const server = new Hapi.Server({debug: false});
+		server.connection();
+
+		server.register({
+			register: require('../'),
+			options: {
+				headers: {
+					foo: 'bar'
+				}
+			}
+		})
+			.then(() => {
+				server.route({method: 'GET', path: '/', handler: (req, reply) => reply(Boom.badData('foo'))});
+				server
+					.inject({
+						url: '/',
+						method: 'GET'
+					})
+					.then((res) => {
+						assert(res.headers.foo === 'bar');
 						done();
 					});
 			})


### PR DESCRIPTION
The response object for Boom errors is different from normal response objects, meaning among other things that `.headers()` is not available. The same effect can be achieved by accessing `response.output.headers` instead.
